### PR TITLE
Increase read buffer size to avoid stack smasher

### DIFF
--- a/bicon/pty_spawn.h
+++ b/bicon/pty_spawn.h
@@ -3,7 +3,7 @@
 #include <unistd.h>
 #include <stdio.h>
 
-#define BUFLEN BUFSIZ
+#define BUFLEN BUFSIZ*2
 
 typedef ssize_t (
   *reader) (


### PR DESCRIPTION
The crash mentioned in your README is caused by `bicon_read` overrunning its input buffer (`buf`) under some circumstances (I suspect because of the `\b` added?). The code does not seem to check whether it's safe to add more data to the buffer, and with the read buffers (`input`) the same size as `buf`, accidents happen occasionally.
Making this code truly robust would probably require a substantial rework of the code, but a simple, pragmatic solution is simply to make the input buffer considerably larger than the read buffer. With the proposed PR, your test case no longer crashes.